### PR TITLE
Converting anonymous inner classes with one method into lambdas

### DIFF
--- a/src/main/java/com/johnwesthoff/bending/Server.java
+++ b/src/main/java/com/johnwesthoff/bending/Server.java
@@ -327,9 +327,8 @@ public final class Server implements Runnable {
     public Thread expander;
 
     public void startExpander() {
-        expander = new Thread(new Runnable() {
-            @Override
-            public void run() {
+        expander = new Thread(
+            () -> {
                 while (gameRunning) {
                     loadMap(mapRotation);
                     try {
@@ -339,7 +338,7 @@ public final class Server implements Runnable {
                     }
                 }
             }
-        });
+        );
         expander.start();
     }
 

--- a/src/main/java/com/johnwesthoff/bending/logic/World.java
+++ b/src/main/java/com/johnwesthoff/bending/logic/World.java
@@ -240,9 +240,10 @@ public class World implements Serializable {
      * @param colors2
      */
     public void load(final byte parts[], final int colors[], final int colors2[]) {
-        Runnable getStuff = new Runnable() {
-            @Override
-            public void run() {
+        Runnable getStuff =
+            /* Per sonic-lint, declaring a new instance of a single-method class was a bad smell, and for readability
+               it is more appropriate to replace with a lambda method */
+            () -> {
                 bodyParts = new Image[parts.length];
                 try {
                     for (int i = 0; i < parts.length; i++) {
@@ -259,8 +260,7 @@ public class World implements Serializable {
                 }
                 bodyParts[0] = World.changeColor((BufferedImage) bodyParts[0], Color.white, Color.red);
                 done = true;
-            }
-        };
+            };
         loader = new Thread(getStuff);
         loader.start();
     }

--- a/src/main/java/com/johnwesthoff/bending/ui/ClothingChooser1.java
+++ b/src/main/java/com/johnwesthoff/bending/ui/ClothingChooser1.java
@@ -444,10 +444,10 @@ public class ClothingChooser1 extends javax.swing.JPanel implements Runnable {
      * Loads the images
      */
     public void getImages() {
-        Runnable getStuff = new Runnable() {
-
-            @Override
-            public void run() {
+        Runnable getStuff =
+            /* Originally declared as a new Runnable instance with a single method; To resolve sonic-lint warning java:S1604
+               converted into a single lambda function without any change to the method body. */
+            (() -> {
                 try {
                     done = false;
                     for (int i = 0; i < cloths.length; i++) {
@@ -466,8 +466,7 @@ public class ClothingChooser1 extends javax.swing.JPanel implements Runnable {
 
                     ex.printStackTrace();
                 }
-            }
-        };
+            });
         if (getTem != null) {
             getTem.interrupt();
         }

--- a/src/main/java/com/johnwesthoff/bending/ui/ClothingChooser1.java
+++ b/src/main/java/com/johnwesthoff/bending/ui/ClothingChooser1.java
@@ -116,172 +116,80 @@ public class ClothingChooser1 extends javax.swing.JPanel implements Runnable {
         // jPanel1.setForeground(new java.awt.Color(51, 255, 255));
 
         buttonHead.setText("Head");
-        buttonHead.addActionListener(new java.awt.event.ActionListener() {
-            @Override
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
-                buttonHeadActionPerformed(evt);
-            }
-        });
+        buttonHead.addActionListener(event -> buttonHeadActionPerformed(event));        
 
         buttonHeadcolor.setText("Head Color");
-        buttonHeadcolor.addActionListener(new java.awt.event.ActionListener() {
-            @Override
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
-                buttonHeadcolorActionPerformed(evt);
-            }
-        });
+        buttonHeadcolor.addActionListener(event ->
+                            buttonHeadcolorActionPerformed(event));
 
         buttonBodycolor.setText("Body Color");
-        buttonBodycolor.addActionListener(new java.awt.event.ActionListener() {
-            @Override
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
-                buttonBodycolorActionPerformed(evt);
-            }
-        });
+        buttonBodycolor.addActionListener(event ->
+                            buttonBodycolorActionPerformed(event));
 
         buttonScolor.setText("Shoulder Color");
-        buttonScolor.addActionListener(new java.awt.event.ActionListener() {
-            @Override
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
-                buttonScolorActionPerformed(evt);
-            }
-        });
+        buttonScolor.addActionListener(event ->
+                            buttonScolorActionPerformed(event));
 
         buttonFcolor.setText("Fore Arm Color");
-        buttonFcolor.addActionListener(new java.awt.event.ActionListener() {
-            @Override
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
-                buttonFcolorActionPerformed(evt);
-            }
-        });
+        buttonFcolor.addActionListener(event ->
+                            buttonFcolorActionPerformed(event));
 
         buttonTcolor.setText("Thigh Color");
-        buttonTcolor.addActionListener(new java.awt.event.ActionListener() {
-            @Override
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
-                buttonTcolorActionPerformed(evt);
-            }
-        });
+        buttonTcolor.addActionListener(event ->
+                            buttonTcolorActionPerformed(event));
 
         buttonShincolor.setText("Shin Color");
-        buttonShincolor.addActionListener(new java.awt.event.ActionListener() {
-            @Override
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
-                buttonShincolorActionPerformed(evt);
-            }
-        });
+        buttonShincolor.addActionListener(event ->
+                            buttonShincolorActionPerformed(event));
 
         buttonHeadcolor2.setText("Head Color 2");
-        buttonHeadcolor2.addActionListener(new java.awt.event.ActionListener() {
-            @Override
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
-                COLOR(1, evt);
-            }
-        });
+        buttonHeadcolor2.addActionListener(event -> COLOR(1, event));
 
         buttonBodycolor2.setText("Body Color 2");
-        buttonBodycolor2.addActionListener(new java.awt.event.ActionListener() {
-            @Override
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
-                COLOR(0, evt);
-            }
-        });
+        buttonBodycolor2.addActionListener(event -> COLOR(0, event));
 
         buttonScolor2.setText("Shoulder Color 2");
-        buttonScolor2.addActionListener(new java.awt.event.ActionListener() {
-            @Override
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
-                COLOR(2, evt);
-            }
-        });
+        buttonScolor2.addActionListener(event -> COLOR(2, event));
 
         buttonFcolor2.setText("Fore Arm Color 2");
-        buttonFcolor2.addActionListener(new java.awt.event.ActionListener() {
-            @Override
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
-                COLOR(3, evt);
-            }
-        });
+        buttonFcolor2.addActionListener(event -> COLOR(3, event));
 
         buttonTcolor2.setText("Thigh Color 2");
-        buttonTcolor2.addActionListener(new java.awt.event.ActionListener() {
-            @Override
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
-                COLOR(4, evt);
-            }
-        });
+        buttonTcolor2.addActionListener(event -> COLOR(4, event));
 
         buttonShincolor2.setText("Shin Color 2");
-        buttonShincolor2.addActionListener(new java.awt.event.ActionListener() {
-            @Override
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
-                COLOR(5, evt);
-            }
-        });
+        buttonShincolor2.addActionListener(event -> COLOR(5, event));
 
         buttonBody.setText("Body");
-        buttonBody.addActionListener(new java.awt.event.ActionListener() {
-            @Override
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
-                buttonBodyActionPerformed(evt);
-            }
-        });
+        buttonBody.addActionListener(event ->
+                            buttonBodyActionPerformed(event));
 
         buttonShoulder.setText("Shoulder");
-        buttonShoulder.addActionListener(new java.awt.event.ActionListener() {
-            @Override
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
-                buttonShoulderActionPerformed(evt);
-            }
-        });
+        buttonShoulder.addActionListener(event -> 
+                            buttonShoulderActionPerformed(event));
 
         ForeArm.setText("ForeArm");
-        ForeArm.addActionListener(new java.awt.event.ActionListener() {
-            @Override
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
-                ForeArmActionPerformed(evt);
-            }
-        });
+        ForeArm.addActionListener(event -> ForeArmActionPerformed(event));
 
         ThighButton.setText("Thigh");
-        ThighButton.addActionListener(new java.awt.event.ActionListener() {
-            @Override
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
-                ThighButtonActionPerformed(evt);
-            }
-        });
+        ThighButton.addActionListener(event ->
+                            ThighButtonActionPerformed(event));
 
         buttonShin.setText("Shin");
-        buttonShin.addActionListener(new java.awt.event.ActionListener() {
-            @Override
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
-                buttonShinActionPerformed(evt);
-            }
-        });
+        buttonShin.addActionListener(event ->
+                            buttonShinActionPerformed(event));
 
         jButton1.setText("Save");
-        jButton1.addActionListener(new java.awt.event.ActionListener() {
-            @Override
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
-                jButton1ActionPerformed(evt);
-            }
-        });
+        jButton1.addActionListener(event ->
+                            jButton1ActionPerformed(event));
 
         jButton2.setText("Load");
-        jButton2.addActionListener(new java.awt.event.ActionListener() {
-            @Override
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
-                jButton2ActionPerformed(evt);
-            }
-        });
+        jButton2.addActionListener(event ->
+                            jButton2ActionPerformed(event));
 
         jButton3.setText("Finish");
-        jButton3.addActionListener(new java.awt.event.ActionListener() {
-            @Override
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
-                jButton3ActionPerformed(evt);
-            }
-        });
+        jButton3.addActionListener(event ->
+                            jButton3ActionPerformed(event));
 
         javax.swing.GroupLayout jPanel1Layout = new javax.swing.GroupLayout(this);
         setLayout(jPanel1Layout);

--- a/src/main/java/com/johnwesthoff/bending/ui/ClothingChooser1.java
+++ b/src/main/java/com/johnwesthoff/bending/ui/ClothingChooser1.java
@@ -116,31 +116,64 @@ public class ClothingChooser1 extends javax.swing.JPanel implements Runnable {
         // jPanel1.setForeground(new java.awt.Color(51, 255, 255));
 
         buttonHead.setText("Head");
-        buttonHead.addActionListener(event -> buttonHeadActionPerformed(event));        
+        buttonHead.addActionListener(event -> {
+            cloths[1]++;
+            if (cloths[1] == 4 && !Client.unlocks.get(0, 1)) {
+                cloths[1]++;
+            }
+            if (cloths[1] > waffles2) {
+                cloths[1] = 1;
+            }
+            getImages();
+        });        
 
         buttonHeadcolor.setText("Head Color");
-        buttonHeadcolor.addActionListener(event ->
-                            buttonHeadcolorActionPerformed(event));
+        buttonHeadcolor.addActionListener(event -> {
+            colors[1] = JColorChooser.showDialog(this, "Choose Head Color", colors[1]);
+            if (colors[1] == null)
+                colors[1] = Color.BLACK;
+            getImages();
+        });
 
         buttonBodycolor.setText("Body Color");
-        buttonBodycolor.addActionListener(event ->
-                            buttonBodycolorActionPerformed(event));
+        buttonBodycolor.addActionListener(event -> {
+            colors[0] = JColorChooser.showDialog(this, "Choose Body Color", colors[0]);
+            if (colors[0] == null)
+                colors[0] = Color.BLACK;
+            getImages();
+        });
 
         buttonScolor.setText("Shoulder Color");
-        buttonScolor.addActionListener(event ->
-                            buttonScolorActionPerformed(event));
+        buttonScolor.addActionListener(event -> {
+            colors[2] = JColorChooser.showDialog(this, "Choose Shoulder Color", colors[2]);
+            if (colors[2] == null)
+                colors[2] = Color.BLACK;
+            getImages();
+        });
 
         buttonFcolor.setText("Fore Arm Color");
-        buttonFcolor.addActionListener(event ->
-                            buttonFcolorActionPerformed(event));
+        buttonFcolor.addActionListener(event -> {
+            colors[3] = JColorChooser.showDialog(this, "Choose Arm Color", colors[3]);
+            if (colors[3] == null)
+                colors[3] = Color.BLACK;
+            getImages();
+        });
 
         buttonTcolor.setText("Thigh Color");
-        buttonTcolor.addActionListener(event ->
-                            buttonTcolorActionPerformed(event));
+        buttonTcolor.addActionListener(event -> {
+            colors[4] = JColorChooser.showDialog(this, "Choose Leg Color", colors[4]);
+            if (colors[4] == null)
+                colors[4] = Color.BLACK;
+            getImages();
+        });
 
         buttonShincolor.setText("Shin Color");
-        buttonShincolor.addActionListener(event ->
-                            buttonShincolorActionPerformed(event));
+        buttonShincolor.addActionListener(event -> {
+            colors[5] = JColorChooser.showDialog(this, "Choose Foot Color", colors[5]);
+            if (colors[5] == null)
+                colors[5] = Color.BLACK;
+            getImages();
+        });
 
         buttonHeadcolor2.setText("Head Color 2");
         buttonHeadcolor2.addActionListener(event -> COLOR(1, event));
@@ -161,35 +194,87 @@ public class ClothingChooser1 extends javax.swing.JPanel implements Runnable {
         buttonShincolor2.addActionListener(event -> COLOR(5, event));
 
         buttonBody.setText("Body");
-        buttonBody.addActionListener(event ->
-                            buttonBodyActionPerformed(event));
+        buttonBody.addActionListener(event -> {
+            cloths[0]++;
+            if (cloths[0] > waffles) {
+                cloths[0] = 1;
+            }
+            getImages();
+        });
 
         buttonShoulder.setText("Shoulder");
-        buttonShoulder.addActionListener(event -> 
-                            buttonShoulderActionPerformed(event));
+        buttonShoulder.addActionListener(event -> {
+            cloths[2]++;
+            if (cloths[2] > waffles) {
+                cloths[2] = 1;
+            }
+            getImages();
+        });
 
         ForeArm.setText("ForeArm");
-        ForeArm.addActionListener(event -> ForeArmActionPerformed(event));
+        ForeArm.addActionListener(event -> {
+            cloths[3]++;
+            if (cloths[3] > waffles) {
+                cloths[3] = 1;
+            }
+            getImages();
+        });
 
         ThighButton.setText("Thigh");
-        ThighButton.addActionListener(event ->
-                            ThighButtonActionPerformed(event));
+        ThighButton.addActionListener(event -> {
+            cloths[4]++;
+            if (cloths[4] > waffles) {
+                cloths[4] = 1;
+            }
+            getImages();
+        });
 
         buttonShin.setText("Shin");
-        buttonShin.addActionListener(event ->
-                            buttonShinActionPerformed(event));
+        buttonShin.addActionListener(event -> {
+            cloths[5]++;
+            if (cloths[5] > waffles) {
+                cloths[5] = 1;
+            }
+            getImages();
+        });
 
         jButton1.setText("Save");
-        jButton1.addActionListener(event ->
-                            jButton1ActionPerformed(event));
+        jButton1.addActionListener(event -> {
+            if (Client.currentlyLoggedIn) {
+                String post = "";
+                for (int i = 0; i < cloths.length; i++) {
+                    post += cloths[i];
+                    post += ",";
+                }
+                for (int i = 0; i < colors.length; i++) {
+                    post += colors[i].getRGB();
+                    post += ",";
+                }
+                for (int i = 0; i < colors2.length; i++) {
+                    post += colors2[i].getRGB();
+                    post += i == colors2.length - 1 ? "" : ",";
+                }
+                // System.out.println(post);
+                avatarService.changesAppearance(post, Client.jtb.getText());
+            }
+        });
 
         jButton2.setText("Load");
-        jButton2.addActionListener(event ->
-                            jButton2ActionPerformed(event));
+        jButton2.addActionListener(event -> {
+            if (Client.currentlyLoggedIn) {
+                loadClothing();
+            }
+        });
 
         jButton3.setText("Finish");
-        jButton3.addActionListener(event ->
-                            jButton3ActionPerformed(event));
+        jButton3.addActionListener(event -> {
+            Client.Clothing = cloths;
+            for (int i = 0; i < colors.length; i++) {
+                Client.Colors[i] = colors[i].getRGB();
+                Client.Colors2[i] = colors2[i].getRGB();
+            }
+            Client.immaKeepTabsOnYou.setSelectedIndex(0);
+        });
 
         javax.swing.GroupLayout jPanel1Layout = new javax.swing.GroupLayout(this);
         setLayout(jPanel1Layout);
@@ -271,154 +356,12 @@ public class ClothingChooser1 extends javax.swing.JPanel implements Runnable {
 
     }// </editor-fold>
 
-    private void buttonHeadActionPerformed(java.awt.event.ActionEvent evt) {
-
-        cloths[1]++;
-        if (cloths[1] == 4 && !Client.unlocks.get(0, 1)) {
-            cloths[1]++;
-        }
-        if (cloths[1] > waffles2) {
-            cloths[1] = 1;
-        }
-        getImages();
-    }
-
     private void COLOR(int i, java.awt.event.ActionEvent evt) {
 
         colors2[i] = JColorChooser.showDialog(this, "Choose Secondary Color", colors[i]);
         if (colors2[i] == null)
             colors2[i] = Color.BLACK;
         getImages();
-    }
-
-    private void buttonHeadcolorActionPerformed(java.awt.event.ActionEvent evt) {
-
-        colors[1] = JColorChooser.showDialog(this, "Choose Head Color", colors[1]);
-        if (colors[1] == null)
-            colors[1] = Color.BLACK;
-        getImages();
-    }
-
-    private void buttonBodycolorActionPerformed(java.awt.event.ActionEvent evt) {
-
-        colors[0] = JColorChooser.showDialog(this, "Choose Body Color", colors[0]);
-        if (colors[0] == null)
-            colors[0] = Color.BLACK;
-        getImages();
-    }
-
-    private void buttonScolorActionPerformed(java.awt.event.ActionEvent evt) {
-
-        colors[2] = JColorChooser.showDialog(this, "Choose Shoulder Color", colors[2]);
-        if (colors[2] == null)
-            colors[2] = Color.BLACK;
-        getImages();
-    }
-
-    private void buttonFcolorActionPerformed(java.awt.event.ActionEvent evt) {
-
-        colors[3] = JColorChooser.showDialog(this, "Choose Arm Color", colors[3]);
-        if (colors[3] == null)
-            colors[3] = Color.BLACK;
-        getImages();
-    }
-
-    private void buttonTcolorActionPerformed(java.awt.event.ActionEvent evt) {
-
-        colors[4] = JColorChooser.showDialog(this, "Choose Leg Color", colors[4]);
-        if (colors[4] == null)
-            colors[4] = Color.BLACK;
-        getImages();
-    }
-
-    private void buttonShincolorActionPerformed(java.awt.event.ActionEvent evt) {
-
-        colors[5] = JColorChooser.showDialog(this, "Choose Foot Color", colors[5]);
-        if (colors[5] == null)
-            colors[5] = Color.BLACK;
-        getImages();
-    }
-
-    private void buttonBodyActionPerformed(java.awt.event.ActionEvent evt) {
-
-        cloths[0]++;
-        if (cloths[0] > waffles) {
-            cloths[0] = 1;
-        }
-        getImages();
-    }
-
-    private void buttonShoulderActionPerformed(java.awt.event.ActionEvent evt) {
-
-        cloths[2]++;
-        if (cloths[2] > waffles) {
-            cloths[2] = 1;
-        }
-        getImages();
-    }
-
-    private void ForeArmActionPerformed(java.awt.event.ActionEvent evt) {
-
-        cloths[3]++;
-        if (cloths[3] > waffles) {
-            cloths[3] = 1;
-        }
-        getImages();
-    }
-
-    private void ThighButtonActionPerformed(java.awt.event.ActionEvent evt) {
-
-        cloths[4]++;
-        if (cloths[4] > waffles) {
-            cloths[4] = 1;
-        }
-        getImages();
-    }
-
-    private void buttonShinActionPerformed(java.awt.event.ActionEvent evt) {
-
-        cloths[5]++;
-        if (cloths[5] > waffles) {
-            cloths[5] = 1;
-        }
-        getImages();
-    }
-
-    private void jButton1ActionPerformed(java.awt.event.ActionEvent evt) {
-        if (Client.currentlyLoggedIn) {
-            String post = "";
-            for (int i = 0; i < cloths.length; i++) {
-                post += cloths[i];
-                post += ",";
-            }
-            for (int i = 0; i < colors.length; i++) {
-                post += colors[i].getRGB();
-                post += ",";
-            }
-            for (int i = 0; i < colors2.length; i++) {
-                post += colors2[i].getRGB();
-                post += i == colors2.length - 1 ? "" : ",";
-            }
-            // System.out.println(post);
-            avatarService.changesAppearance(post, Client.jtb.getText());
-        }
-    }
-
-    private void jButton2ActionPerformed(java.awt.event.ActionEvent evt) {
-
-        if (Client.currentlyLoggedIn) {
-            loadClothing();
-        }
-    }
-
-    private void jButton3ActionPerformed(java.awt.event.ActionEvent evt) {
-
-        Client.Clothing = cloths;
-        for (int i = 0; i < colors.length; i++) {
-            Client.Colors[i] = colors[i].getRGB();
-            Client.Colors2[i] = colors2[i].getRGB();
-        }
-        Client.immaKeepTabsOnYou.setSelectedIndex(0);
     }
 
     /**

--- a/src/main/java/com/johnwesthoff/bending/ui/MapMaker.java
+++ b/src/main/java/com/johnwesthoff/bending/ui/MapMaker.java
@@ -165,19 +165,19 @@ public class MapMaker extends javax.swing.JFrame implements Runnable, MouseMotio
         setDefaultCloseOperation(javax.swing.WindowConstants.DISPOSE_ON_CLOSE);
 
         jButton1.setText("Grass");
-        jButton1.addActionListener(event -> jButton1ActionPerformed(event));
+        jButton1.addActionListener(event -> {kind = GROUND;});
 
         jButton2.setText("Stone");
-        jButton2.addActionListener(event -> jButton2ActionPerformed(event));
+        jButton2.addActionListener(event -> {kind = STONE;});
 
         jButton3.setText("Ice");
-        jButton3.addActionListener(event -> jButton3ActionPerformed(event));
+        jButton3.addActionListener(event -> {kind = ICE;});
 
         jButton4.setText("Water");
-        jButton4.addActionListener(event -> jButton4ActionPerformed(event));
+        jButton4.addActionListener(event -> {kind = WATER;});
 
         jButton5.setText("Lava");
-        jButton5.addActionListener(event -> jButton5ActionPerformed(event));
+        jButton5.addActionListener(event -> {kind = LAVA;});
 
         thickness.setMajorTickSpacing(25);
         thickness.setMaximum(300);
@@ -188,26 +188,26 @@ public class MapMaker extends javax.swing.JFrame implements Runnable, MouseMotio
         thickness.setInverted(true);
 
         jButton6.setText("Sand");
-        jButton6.addActionListener(event -> jButton6ActionPerformed(event));
+        jButton6.addActionListener(event -> {kind = SAND;});
 
         jButton7.setText("Bark");
-        jButton7.addActionListener(event -> jButton7ActionPerformed(event));
+        jButton7.addActionListener(event -> {kind = TREE;});
 
         jButton8.setText("Sky");
-        jButton8.addActionListener(event -> jButton8ActionPerformed(event));
+        jButton8.addActionListener(event -> {kind = AIR;});
 
         jButton9.setText("Save Map");
-        jButton9.addActionListener(event -> jButton9ActionPerformed(event));
+        jButton9.addActionListener(event -> save());
 
         jButton10.setText("Load Map");
-        jButton10.addActionListener(event -> jButton10ActionPerformed(event));
+        jButton10.addActionListener(event -> load());
 
         buffering.setBackground(new java.awt.Color(0, 51, 255));
         buffering.setForeground(new java.awt.Color(255, 255, 0));
         buffering.setValue(50);
 
         jButton11.setText("Crystal");
-        jButton11.addActionListener(event -> jButton11ActionPerformed(event));
+        jButton11.addActionListener(event -> {kind = CRYSTAL;});
 
         jComboBox1.setModel(new javax.swing.DefaultComboBoxModel<Object>(
                 new String[] { "900x900", "400x400", "1200x1200", "2000x900", "900x2000", "2000x2000" }));
@@ -234,10 +234,10 @@ public class MapMaker extends javax.swing.JFrame implements Runnable, MouseMotio
         jScrollPane2.setViewportView(jScrollPane1);
 
         jButton12.setText("Load Image");
-        jButton12.addActionListener(event -> jButton12ActionPerformed(event));
+        jButton12.addActionListener(event -> loadPicture());
 
         jButton13.setText("Ether");
-        jButton13.addActionListener(event -> jButton13ActionPerformed(event));
+        jButton13.addActionListener(event -> {kind = ETHER;});
 
         jMenuBar1.setBackground(new java.awt.Color(250, 250, 250));
         jMenuBar1.setBorder(javax.swing.BorderFactory.createEtchedBorder());
@@ -248,13 +248,13 @@ public class MapMaker extends javax.swing.JFrame implements Runnable, MouseMotio
                 javax.swing.KeyStroke.getKeyStroke(java.awt.event.KeyEvent.VK_S, java.awt.event.InputEvent.CTRL_DOWN_MASK));
         jMenuItem1.setText("Save");
         jMenuItem1.setBorderPainted(true);
-        jMenuItem1.addActionListener(event -> jMenuItem1ActionPerformed(evt));
+        jMenuItem1.addActionListener(event -> save());
         jMenu1.add(jMenuItem1);
 
         jMenuItem2.setAccelerator(
                 javax.swing.KeyStroke.getKeyStroke(java.awt.event.KeyEvent.VK_L, java.awt.event.InputEvent.CTRL_DOWN_MASK));
         jMenuItem2.setText("Load");
-        jMenuItem2.addActionListener(event -> jMenuItem2ActionPerformed(event));
+        jMenuItem2.addActionListener(event -> load());
         jMenu1.add(jMenuItem2);
         jMenu1.add(jSeparator1);
 
@@ -263,7 +263,12 @@ public class MapMaker extends javax.swing.JFrame implements Runnable, MouseMotio
         jMenu2.setText("Edit");
 
         jMenuItem3.setText("Clear");
-        jMenuItem3.addActionListener(event -> jMenuItem3ActionPerformed(event));
+        jMenuItem3.addActionListener(event -> {
+            writeData = new byte[900][900];
+            bg.setPaint(skyPaint);
+            bg.fillRect(0, 0, 900, 900);
+            EditingPane.repaint();
+        });
         jMenu2.add(jMenuItem3);
 
         jMenuBar1.add(jMenu2);
@@ -389,75 +394,6 @@ public class MapMaker extends javax.swing.JFrame implements Runnable, MouseMotio
 
         pack();
     }// </editor-fold>//GEN-END:initComponents
-
-    private void jButton1ActionPerformed(java.awt.event.ActionEvent evt) {// GEN-FIRST:event_jButton1ActionPerformed
-        kind = GROUND;
-    }// GEN-LAST:event_jButton1ActionPerformed
-
-    private void jButton2ActionPerformed(java.awt.event.ActionEvent evt) {// GEN-FIRST:event_jButton2ActionPerformed
-        kind = STONE;
-    }// GEN-LAST:event_jButton2ActionPerformed
-
-    private void jButton3ActionPerformed(java.awt.event.ActionEvent evt) {// GEN-FIRST:event_jButton3ActionPerformed
-        kind = ICE;
-    }// GEN-LAST:event_jButton3ActionPerformed
-
-    private void jButton4ActionPerformed(java.awt.event.ActionEvent evt) {// GEN-FIRST:event_jButton4ActionPerformed
-        kind = WATER;
-    }// GEN-LAST:event_jButton4ActionPerformed
-
-    private void jButton5ActionPerformed(java.awt.event.ActionEvent evt) {// GEN-FIRST:event_jButton5ActionPerformed
-        kind = LAVA;
-    }// GEN-LAST:event_jButton5ActionPerformed
-
-    private void jButton6ActionPerformed(java.awt.event.ActionEvent evt) {// GEN-FIRST:event_jButton6ActionPerformed
-        kind = SAND;
-    }// GEN-LAST:event_jButton6ActionPerformed
-
-    private void jButton7ActionPerformed(java.awt.event.ActionEvent evt) {// GEN-FIRST:event_jButton7ActionPerformed
-        kind = TREE;
-    }// GEN-LAST:event_jButton7ActionPerformed
-
-    private void jButton8ActionPerformed(java.awt.event.ActionEvent evt) {// GEN-FIRST:event_jButton8ActionPerformed
-        kind = AIR;
-    }// GEN-LAST:event_jButton8ActionPerformed
-
-    private void jButton9ActionPerformed(java.awt.event.ActionEvent evt) {// GEN-FIRST:event_jButton9ActionPerformed
-        save();
-    }// GEN-LAST:event_jButton9ActionPerformed
-
-    private void jButton10ActionPerformed(java.awt.event.ActionEvent evt) {// GEN-FIRST:event_jButton10ActionPerformed
-        load();
-    }// GEN-LAST:event_jButton10ActionPerformed
-
-    private void jMenuItem1ActionPerformed(java.awt.event.ActionEvent evt) {// GEN-FIRST:event_jMenuItem1ActionPerformed
-        save();
-    }// GEN-LAST:event_jMenuItem1ActionPerformed
-
-    private void jMenuItem2ActionPerformed(java.awt.event.ActionEvent evt) {// GEN-FIRST:event_jMenuItem2ActionPerformed
-        load();
-    }// GEN-LAST:event_jMenuItem2ActionPerformed
-
-    private void jMenuItem3ActionPerformed(java.awt.event.ActionEvent evt) {// GEN-FIRST:event_jMenuItem3ActionPerformed
-
-        writeData = new byte[900][900];
-        bg.setPaint(skyPaint);
-        bg.fillRect(0, 0, 900, 900);
-        EditingPane.repaint();
-    }// GEN-LAST:event_jMenuItem3ActionPerformed
-
-    private void jButton11ActionPerformed(java.awt.event.ActionEvent evt) {// GEN-FIRST:event_jButton11ActionPerformed
-        kind = CRYSTAL;
-    }// GEN-LAST:event_jButton11ActionPerformed
-
-    private void jButton12ActionPerformed(java.awt.event.ActionEvent evt) {// GEN-FIRST:event_jButton12ActionPerformed
-
-        loadPicture();
-    }// GEN-LAST:event_jButton12ActionPerformed
-
-    private void jButton13ActionPerformed(java.awt.event.ActionEvent evt) {// GEN-FIRST:event_jButton13ActionPerformed
-        kind = ETHER;
-    }// GEN-LAST:event_jButton13ActionPerformed
 
     /**
      * @param args the command line arguments

--- a/src/main/java/com/johnwesthoff/bending/ui/MapMaker.java
+++ b/src/main/java/com/johnwesthoff/bending/ui/MapMaker.java
@@ -165,39 +165,19 @@ public class MapMaker extends javax.swing.JFrame implements Runnable, MouseMotio
         setDefaultCloseOperation(javax.swing.WindowConstants.DISPOSE_ON_CLOSE);
 
         jButton1.setText("Grass");
-        jButton1.addActionListener(new java.awt.event.ActionListener() {
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
-                jButton1ActionPerformed(evt);
-            }
-        });
+        jButton1.addActionListener(event -> jButton1ActionPerformed(event));
 
         jButton2.setText("Stone");
-        jButton2.addActionListener(new java.awt.event.ActionListener() {
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
-                jButton2ActionPerformed(evt);
-            }
-        });
+        jButton2.addActionListener(event -> jButton2ActionPerformed(event));
 
         jButton3.setText("Ice");
-        jButton3.addActionListener(new java.awt.event.ActionListener() {
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
-                jButton3ActionPerformed(evt);
-            }
-        });
+        jButton3.addActionListener(event -> jButton3ActionPerformed(event));
 
         jButton4.setText("Water");
-        jButton4.addActionListener(new java.awt.event.ActionListener() {
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
-                jButton4ActionPerformed(evt);
-            }
-        });
+        jButton4.addActionListener(event -> jButton4ActionPerformed(event));
 
         jButton5.setText("Lava");
-        jButton5.addActionListener(new java.awt.event.ActionListener() {
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
-                jButton5ActionPerformed(evt);
-            }
-        });
+        jButton5.addActionListener(event -> jButton5ActionPerformed(event));
 
         thickness.setMajorTickSpacing(25);
         thickness.setMaximum(300);
@@ -208,50 +188,26 @@ public class MapMaker extends javax.swing.JFrame implements Runnable, MouseMotio
         thickness.setInverted(true);
 
         jButton6.setText("Sand");
-        jButton6.addActionListener(new java.awt.event.ActionListener() {
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
-                jButton6ActionPerformed(evt);
-            }
-        });
+        jButton6.addActionListener(event -> jButton6ActionPerformed(event));
 
         jButton7.setText("Bark");
-        jButton7.addActionListener(new java.awt.event.ActionListener() {
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
-                jButton7ActionPerformed(evt);
-            }
-        });
+        jButton7.addActionListener(event -> jButton7ActionPerformed(event));
 
         jButton8.setText("Sky");
-        jButton8.addActionListener(new java.awt.event.ActionListener() {
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
-                jButton8ActionPerformed(evt);
-            }
-        });
+        jButton8.addActionListener(event -> jButton8ActionPerformed(event));
 
         jButton9.setText("Save Map");
-        jButton9.addActionListener(new java.awt.event.ActionListener() {
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
-                jButton9ActionPerformed(evt);
-            }
-        });
+        jButton9.addActionListener(event -> jButton9ActionPerformed(event));
 
         jButton10.setText("Load Map");
-        jButton10.addActionListener(new java.awt.event.ActionListener() {
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
-                jButton10ActionPerformed(evt);
-            }
-        });
+        jButton10.addActionListener(event -> jButton10ActionPerformed(event));
 
         buffering.setBackground(new java.awt.Color(0, 51, 255));
         buffering.setForeground(new java.awt.Color(255, 255, 0));
         buffering.setValue(50);
 
         jButton11.setText("Crystal");
-        jButton11.addActionListener(new java.awt.event.ActionListener() {
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
-                jButton11ActionPerformed(evt);
-            }
-        });
+        jButton11.addActionListener(event -> jButton11ActionPerformed(event));
 
         jComboBox1.setModel(new javax.swing.DefaultComboBoxModel<Object>(
                 new String[] { "900x900", "400x400", "1200x1200", "2000x900", "900x2000", "2000x2000" }));
@@ -278,18 +234,10 @@ public class MapMaker extends javax.swing.JFrame implements Runnable, MouseMotio
         jScrollPane2.setViewportView(jScrollPane1);
 
         jButton12.setText("Load Image");
-        jButton12.addActionListener(new java.awt.event.ActionListener() {
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
-                jButton12ActionPerformed(evt);
-            }
-        });
+        jButton12.addActionListener(event -> jButton12ActionPerformed(event));
 
         jButton13.setText("Ether");
-        jButton13.addActionListener(new java.awt.event.ActionListener() {
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
-                jButton13ActionPerformed(evt);
-            }
-        });
+        jButton13.addActionListener(event -> jButton13ActionPerformed(event));
 
         jMenuBar1.setBackground(new java.awt.Color(250, 250, 250));
         jMenuBar1.setBorder(javax.swing.BorderFactory.createEtchedBorder());
@@ -300,21 +248,13 @@ public class MapMaker extends javax.swing.JFrame implements Runnable, MouseMotio
                 javax.swing.KeyStroke.getKeyStroke(java.awt.event.KeyEvent.VK_S, java.awt.event.InputEvent.CTRL_DOWN_MASK));
         jMenuItem1.setText("Save");
         jMenuItem1.setBorderPainted(true);
-        jMenuItem1.addActionListener(new java.awt.event.ActionListener() {
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
-                jMenuItem1ActionPerformed(evt);
-            }
-        });
+        jMenuItem1.addActionListener(event -> jMenuItem1ActionPerformed(evt));
         jMenu1.add(jMenuItem1);
 
         jMenuItem2.setAccelerator(
                 javax.swing.KeyStroke.getKeyStroke(java.awt.event.KeyEvent.VK_L, java.awt.event.InputEvent.CTRL_DOWN_MASK));
         jMenuItem2.setText("Load");
-        jMenuItem2.addActionListener(new java.awt.event.ActionListener() {
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
-                jMenuItem2ActionPerformed(evt);
-            }
-        });
+        jMenuItem2.addActionListener(event -> jMenuItem2ActionPerformed(event));
         jMenu1.add(jMenuItem2);
         jMenu1.add(jSeparator1);
 
@@ -323,11 +263,7 @@ public class MapMaker extends javax.swing.JFrame implements Runnable, MouseMotio
         jMenu2.setText("Edit");
 
         jMenuItem3.setText("Clear");
-        jMenuItem3.addActionListener(new java.awt.event.ActionListener() {
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
-                jMenuItem3ActionPerformed(evt);
-            }
-        });
+        jMenuItem3.addActionListener(event -> jMenuItem3ActionPerformed(event));
         jMenu2.add(jMenuItem3);
 
         jMenuBar1.add(jMenu2);
@@ -552,12 +488,11 @@ public class MapMaker extends javax.swing.JFrame implements Runnable, MouseMotio
         // </editor-fold>
 
         /* Create and display the form */
-        java.awt.EventQueue.invokeLater(new Runnable() {
-            @Override
-            public void run() {
+        java.awt.EventQueue.invokeLater(
+            () -> {
                 new MapMaker().setVisible(true);
             }
-        });
+        );
     }
 
     // Variables declaration - do not modify//GEN-BEGIN:variables

--- a/src/main/java/com/johnwesthoff/bending/ui/PassiveChooser1.java
+++ b/src/main/java/com/johnwesthoff/bending/ui/PassiveChooser1.java
@@ -78,11 +78,7 @@ public class PassiveChooser1 extends javax.swing.JPanel {
         jScrollPane1.setViewportView(jList1);
 
         jButton1.setText("Choose");
-        jButton1.addActionListener(new java.awt.event.ActionListener() {
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
-                jButton1ActionPerformed(evt);
-            }
-        });
+        jButton1.addActionListener(event -> jButton1ActionPerformed(event));
 
         javax.swing.GroupLayout layout = new javax.swing.GroupLayout(this);
         setLayout(layout);

--- a/src/main/java/com/johnwesthoff/bending/ui/PassiveChooser1.java
+++ b/src/main/java/com/johnwesthoff/bending/ui/PassiveChooser1.java
@@ -78,7 +78,9 @@ public class PassiveChooser1 extends javax.swing.JPanel {
         jScrollPane1.setViewportView(jList1);
 
         jButton1.setText("Choose");
-        jButton1.addActionListener(event -> jButton1ActionPerformed(event));
+        jButton1.addActionListener(event -> {
+            //TODO: no behavior defined
+        });
 
         javax.swing.GroupLayout layout = new javax.swing.GroupLayout(this);
         setLayout(layout);
@@ -99,10 +101,6 @@ public class PassiveChooser1 extends javax.swing.JPanel {
 
         // pack();
     }// </editor-fold>
-
-    private void jButton1ActionPerformed(java.awt.event.ActionEvent evt) {
-
-    }
 
     public javax.swing.JList<Object> getList() {
         return jList1;

--- a/src/main/java/com/johnwesthoff/bending/ui/Register.java
+++ b/src/main/java/com/johnwesthoff/bending/ui/Register.java
@@ -65,14 +65,20 @@ public class Register extends javax.swing.JFrame implements KeyListener {
 
         jLabel3.setText("Email:");
 
-        password.addActionListener(event -> passwordActionPerformed(event));
+        password.addActionListener(event -> {
+            // Do nothing (potentially run password validation)
+        });
 
-        username.addActionListener(event -> usernameActionPerformed(event));
+        username.addActionListener(event -> {
+            // Do nothing (potentially run user validation)
+        });
 
-        email.addActionListener(event -> emailActionPerformed(event));
+        email.addActionListener(event -> {
+            // Do nothing (potentially run email validation)
+        });
 
         register.setText("Register");
-        register.addActionListener(event -> registerActionPerformed(event));
+        register.addActionListener(event -> registerActionPerformed());
 
         javax.swing.GroupLayout layout = new javax.swing.GroupLayout(getContentPane());
         getContentPane().setLayout(layout);
@@ -117,19 +123,7 @@ public class Register extends javax.swing.JFrame implements KeyListener {
         pack();
     }// </editor-fold>//GEN-END:initComponents
 
-    private void passwordActionPerformed(java.awt.event.ActionEvent evt) {// GEN-FIRST:event_passwordActionPerformed
-
-    }// GEN-LAST:event_passwordActionPerformed
-
-    private void usernameActionPerformed(java.awt.event.ActionEvent evt) {// GEN-FIRST:event_usernameActionPerformed
-
-    }// GEN-LAST:event_usernameActionPerformed
-
-    private void emailActionPerformed(java.awt.event.ActionEvent evt) {// GEN-FIRST:event_emailActionPerformed
-
-    }// GEN-LAST:event_emailActionPerformed
-
-    private void registerActionPerformed(java.awt.event.ActionEvent evt) {// GEN-FIRST:event_registerActionPerformed
+    private void registerActionPerformed() {// GEN-FIRST:event_registerActionPerformed
         String username = this.username.getText();
         String password = this.password.getText();
         String email = this.email.getText();

--- a/src/main/java/com/johnwesthoff/bending/ui/Register.java
+++ b/src/main/java/com/johnwesthoff/bending/ui/Register.java
@@ -65,30 +65,14 @@ public class Register extends javax.swing.JFrame implements KeyListener {
 
         jLabel3.setText("Email:");
 
-        password.addActionListener(new java.awt.event.ActionListener() {
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
-                passwordActionPerformed(evt);
-            }
-        });
+        password.addActionListener(event -> passwordActionPerformed(event));
 
-        username.addActionListener(new java.awt.event.ActionListener() {
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
-                usernameActionPerformed(evt);
-            }
-        });
+        username.addActionListener(event -> usernameActionPerformed(event));
 
-        email.addActionListener(new java.awt.event.ActionListener() {
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
-                emailActionPerformed(evt);
-            }
-        });
+        email.addActionListener(event -> emailActionPerformed(event));
 
         register.setText("Register");
-        register.addActionListener(new java.awt.event.ActionListener() {
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
-                registerActionPerformed(evt);
-            }
-        });
+        register.addActionListener(event -> registerActionPerformed(event));
 
         javax.swing.GroupLayout layout = new javax.swing.GroupLayout(getContentPane());
         getContentPane().setLayout(layout);

--- a/src/main/java/com/johnwesthoff/bending/ui/SpellChooser1.java
+++ b/src/main/java/com/johnwesthoff/bending/ui/SpellChooser1.java
@@ -85,11 +85,7 @@ public class SpellChooser1 extends javax.swing.JPanel {
         jScrollPane1.setViewportView(jList1);
 
         jButton1.setText("Choose");
-        jButton1.addActionListener(new java.awt.event.ActionListener() {
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
-                jButton1ActionPerformed(evt);
-            }
-        });
+        jButton1.addActionListener(event -> jButton1ActionPerformed(event));
 
         javax.swing.GroupLayout layout = new javax.swing.GroupLayout(this);
         setLayout(layout);

--- a/src/main/java/com/johnwesthoff/bending/ui/SpellChooser1.java
+++ b/src/main/java/com/johnwesthoff/bending/ui/SpellChooser1.java
@@ -85,7 +85,9 @@ public class SpellChooser1 extends javax.swing.JPanel {
         jScrollPane1.setViewportView(jList1);
 
         jButton1.setText("Choose");
-        jButton1.addActionListener(event -> jButton1ActionPerformed(event));
+        jButton1.addActionListener(event -> {
+            //TODO: no behavior defined
+        });
 
         javax.swing.GroupLayout layout = new javax.swing.GroupLayout(this);
         setLayout(layout);
@@ -104,10 +106,6 @@ public class SpellChooser1 extends javax.swing.JPanel {
                         .addGap(18, 18, 18).addComponent(jButton1)
                         .addContainerGap(javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)));
     }// </editor-fold>
-
-    private void jButton1ActionPerformed(java.awt.event.ActionEvent evt) {
-
-    }
 
     /**
      * @param args the command line arguments

--- a/src/main/java/com/johnwesthoff/bending/ui/SpellList1.java
+++ b/src/main/java/com/johnwesthoff/bending/ui/SpellList1.java
@@ -167,26 +167,13 @@ public class SpellList1 extends javax.swing.JPanel implements ActionListener, Mo
         jTable1.getColumnModel().getColumn(4).setResizable(false);
 
         jButton1.setText("Finish");
-        jButton1.addActionListener(new java.awt.event.ActionListener() {
-            @Override
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
-                jButton1ActionPerformed(evt);
-            }
-        });
+        jButton1.addActionListener(event -> jButton1ActionPerformed(event));
 
         jButton2.setText("Save");
-        jButton2.addActionListener(new java.awt.event.ActionListener() {
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
-                jButton2ActionPerformed(evt);
-            }
-        });
+        jButton2.addActionListener(event -> jButton2ActionPerformed(event));
 
         jButton3.setText("Load");
-        jButton3.addActionListener(new java.awt.event.ActionListener() {
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
-                jButton3ActionPerformed(evt);
-            }
-        });
+        jButton3.addActionListener(event -> jButton3ActionPerformed(event));
 
         jLabel1.setHorizontalAlignment(javax.swing.SwingConstants.CENTER);
         jLabel1.setText("Presets");
@@ -194,47 +181,27 @@ public class SpellList1 extends javax.swing.JPanel implements ActionListener, Mo
         jButton4.setFont(new java.awt.Font("Tahoma", 0, 10)); // NOI18N
         jButton4.setForeground(new java.awt.Color(255, 0, 0));
         jButton4.setText("Ignis");
-        jButton4.addActionListener(new java.awt.event.ActionListener() {
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
-                jButton4ActionPerformed(evt);
-            }
-        });
+        jButton4.addActionListener(event -> jButton4ActionPerformed(event));
 
         jButton6.setFont(new java.awt.Font("Tahoma", 0, 10)); // NOI18N
         jButton6.setForeground(new java.awt.Color(153, 153, 0));
         jButton6.setText("Electro");
-        jButton6.addActionListener(new java.awt.event.ActionListener() {
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
-                jButton6ActionPerformed(evt);
-            }
-        });
+        jButton6.addActionListener(event -> jButton6ActionPerformed(event));
 
         jButton7.setFont(new java.awt.Font("Tahoma", 0, 10)); // NOI18N
         jButton7.setForeground(new java.awt.Color(51, 153, 0));
         jButton7.setText("Terrae");
-        jButton7.addActionListener(new java.awt.event.ActionListener() {
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
-                jButton7ActionPerformed(evt);
-            }
-        });
+        jButton7.addActionListener(event -> jButton7ActionPerformed(event));
 
         jButton8.setFont(new java.awt.Font("Tahoma", 0, 10)); // NOI18N
         jButton8.setForeground(new java.awt.Color(0, 0, 255));
         jButton8.setText("Aqua");
-        jButton8.addActionListener(new java.awt.event.ActionListener() {
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
-                jButton8ActionPerformed(evt);
-            }
-        });
+        jButton8.addActionListener(event -> jButton8ActionPerformed(event));
 
         jButton9.setFont(new java.awt.Font("Tahoma", 0, 10)); // NOI18N
         jButton9.setForeground(new java.awt.Color(153, 153, 153));
         jButton9.setText("A'ris");
-        jButton9.addActionListener(new java.awt.event.ActionListener() {
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
-                jButton9ActionPerformed(evt);
-            }
-        });
+        jButton9.addActionListener(event -> jButton9ActionPerformed(event));
 
         XP.setText("XP: ");
 

--- a/src/main/java/com/johnwesthoff/bending/ui/SpellList1.java
+++ b/src/main/java/com/johnwesthoff/bending/ui/SpellList1.java
@@ -167,13 +167,34 @@ public class SpellList1 extends javax.swing.JPanel implements ActionListener, Mo
         jTable1.getColumnModel().getColumn(4).setResizable(false);
 
         jButton1.setText("Finish");
-        jButton1.addActionListener(event -> jButton1ActionPerformed(event));
+        jButton1.addActionListener(event -> {Client.immaKeepTabsOnYou.setSelectedIndex(0);});
 
         jButton2.setText("Save");
-        jButton2.addActionListener(event -> jButton2ActionPerformed(event));
+        jButton2.addActionListener(event -> {
+            if (Client.currentlyLoggedIn) {
+                String post = "";
+    
+                for (int y = 0; y < 5; y++) {
+                    post += Spell.passives.indexOf(app.passiveList[y]) + ",";
+                }
+                for (int y = 0; y < 5; y++) {
+                    for (int i = 0; i < app.spellList[app.spellBook].length; i++) {
+                        post += Spell.spells.indexOf(app.spellList[y][i]);
+                        post += (i == app.spellList[y].length - 1) && (y == 4) ? "" : ",";
+                    }
+                }
+    
+                // System.out.println(post+","+app.jtb.getText());
+                spellsService.persistSpellsForUser(post, Client.jtb.getText());
+            }
+        });
 
         jButton3.setText("Load");
-        jButton3.addActionListener(event -> jButton3ActionPerformed(event));
+        jButton3.addActionListener(event -> {
+            if (Client.currentlyLoggedIn) {
+                loadSpells();
+            }
+        });
 
         jLabel1.setHorizontalAlignment(javax.swing.SwingConstants.CENTER);
         jLabel1.setText("Presets");
@@ -181,27 +202,27 @@ public class SpellList1 extends javax.swing.JPanel implements ActionListener, Mo
         jButton4.setFont(new java.awt.Font("Tahoma", 0, 10)); // NOI18N
         jButton4.setForeground(new java.awt.Color(255, 0, 0));
         jButton4.setText("Ignis");
-        jButton4.addActionListener(event -> jButton4ActionPerformed(event));
+        jButton4.addActionListener(event -> jButtonLoadSpells(15));
 
         jButton6.setFont(new java.awt.Font("Tahoma", 0, 10)); // NOI18N
         jButton6.setForeground(new java.awt.Color(153, 153, 0));
         jButton6.setText("Electro");
-        jButton6.addActionListener(event -> jButton6ActionPerformed(event));
+        jButton6.addActionListener(event -> jButtonLoadSpells(20));
 
         jButton7.setFont(new java.awt.Font("Tahoma", 0, 10)); // NOI18N
         jButton7.setForeground(new java.awt.Color(51, 153, 0));
         jButton7.setText("Terrae");
-        jButton7.addActionListener(event -> jButton7ActionPerformed(event));
+        jButton7.addActionListener(event -> jButtonLoadSpells(5));
 
         jButton8.setFont(new java.awt.Font("Tahoma", 0, 10)); // NOI18N
         jButton8.setForeground(new java.awt.Color(0, 0, 255));
         jButton8.setText("Aqua");
-        jButton8.addActionListener(event -> jButton8ActionPerformed(event));
+        jButton8.addActionListener(event -> jButtonLoadSpells(10));
 
         jButton9.setFont(new java.awt.Font("Tahoma", 0, 10)); // NOI18N
         jButton9.setForeground(new java.awt.Color(153, 153, 153));
         jButton9.setText("A'ris");
-        jButton9.addActionListener(event -> jButton9ActionPerformed(event));
+        jButton9.addActionListener(event -> jButtonLoadSpells(0));
 
         XP.setText("XP: ");
 
@@ -296,96 +317,21 @@ public class SpellList1 extends javax.swing.JPanel implements ActionListener, Mo
         // pack();
     }// </editor-fold>//GEN-END:initComponents
 
-    private void jButton1ActionPerformed(java.awt.event.ActionEvent evt) {// GEN-FIRST:event_jButton1ActionPerformed
-
-        Client.immaKeepTabsOnYou.setSelectedIndex(0);
-    }// GEN-LAST:event_jButton1ActionPerformed
-
-    private void jButton2ActionPerformed(java.awt.event.ActionEvent evt) {// GEN-FIRST:event_jButton2ActionPerformed
-        if (Client.currentlyLoggedIn) {
-            String post = "";
-
-            for (int y = 0; y < 5; y++) {
-                post += Spell.passives.indexOf(app.passiveList[y]) + ",";
-            }
-            for (int y = 0; y < 5; y++) {
-                for (int i = 0; i < app.spellList[app.spellBook].length; i++) {
-                    post += Spell.spells.indexOf(app.spellList[y][i]);
-                    post += (i == app.spellList[y].length - 1) && (y == 4) ? "" : ",";
-                }
-            }
-
-            // System.out.println(post+","+app.jtb.getText());
-            spellsService.persistSpellsForUser(post, Client.jtb.getText());
-        }
-    }// GEN-LAST:event_jButton2ActionPerformed
-
-    private void jButton3ActionPerformed(java.awt.event.ActionEvent evt) {// GEN-FIRST:event_jButton3ActionPerformed
-
-        if (Client.currentlyLoggedIn) {
-            loadSpells();
-        }
-    }// GEN-LAST:event_jButton3ActionPerformed
-
-    private void jButton8ActionPerformed(java.awt.event.ActionEvent evt) {// GEN-FIRST:event_jButton8ActionPerformed
-
+    /**
+     * Loads spells for various spell lists.
+     * Loads 5 consecutive spells from Spell.spells, beginning at startIndex.
+     * @param startIndex the starting Spell index
+     */
+    private void jButtonLoadSpells(int startIndex) {
         for (int i = 0; i < app.spellList[app.spellBook].length; i++) {
-            app.spellList[row][i] = Spell.spells.get(i + 10);
+            app.spellList[row][i] = Spell.spells.get(i + startIndex);
         }
         jTable1.getModel().setValueAt(app.spellList[row][0].getName(), row, 0);
         jTable1.getModel().setValueAt(app.spellList[row][1].getName(), row, 1);
         jTable1.getModel().setValueAt(app.spellList[row][2].getName(), row, 2);
         jTable1.getModel().setValueAt(app.spellList[row][3].getName(), row, 3);
         jTable1.getModel().setValueAt(app.spellList[row][4].getName(), row, 4);
-    }// GEN-LAST:event_jButton8ActionPerformed
-
-    private void jButton9ActionPerformed(java.awt.event.ActionEvent evt) {// GEN-FIRST:event_jButton9ActionPerformed
-
-        for (int i = 0; i < app.spellList[app.spellBook].length; i++) {
-            app.spellList[row][i] = Spell.spells.get(i);
-        }
-        jTable1.getModel().setValueAt(app.spellList[row][0].getName(), row, 0);
-        jTable1.getModel().setValueAt(app.spellList[row][1].getName(), row, 1);
-        jTable1.getModel().setValueAt(app.spellList[row][2].getName(), row, 2);
-        jTable1.getModel().setValueAt(app.spellList[row][3].getName(), row, 3);
-        jTable1.getModel().setValueAt(app.spellList[row][4].getName(), row, 4);
-    }// GEN-LAST:event_jButton9ActionPerformed
-
-    private void jButton7ActionPerformed(java.awt.event.ActionEvent evt) {// GEN-FIRST:event_jButton7ActionPerformed
-
-        for (int i = 0; i < app.spellList[app.spellBook].length; i++) {
-            app.spellList[row][i] = Spell.spells.get(i + 5);
-        }
-        jTable1.getModel().setValueAt(app.spellList[row][0].getName(), row, 0);
-        jTable1.getModel().setValueAt(app.spellList[row][1].getName(), row, 1);
-        jTable1.getModel().setValueAt(app.spellList[row][2].getName(), row, 2);
-        jTable1.getModel().setValueAt(app.spellList[row][3].getName(), row, 3);
-        jTable1.getModel().setValueAt(app.spellList[row][4].getName(), row, 4);
-    }// GEN-LAST:event_jButton7ActionPerformed
-
-    private void jButton4ActionPerformed(java.awt.event.ActionEvent evt) {// GEN-FIRST:event_jButton4ActionPerformed
-
-        for (int i = 0; i < app.spellList[app.spellBook].length; i++) {
-            app.spellList[row][i] = Spell.spells.get(i + 15);
-        }
-        jTable1.getModel().setValueAt(app.spellList[row][0].getName(), row, 0);
-        jTable1.getModel().setValueAt(app.spellList[row][1].getName(), row, 1);
-        jTable1.getModel().setValueAt(app.spellList[row][2].getName(), row, 2);
-        jTable1.getModel().setValueAt(app.spellList[row][3].getName(), row, 3);
-        jTable1.getModel().setValueAt(app.spellList[row][4].getName(), row, 4);
-    }// GEN-LAST:event_jButton4ActionPerformed
-
-    private void jButton6ActionPerformed(java.awt.event.ActionEvent evt) {// GEN-FIRST:event_jButton6ActionPerformed
-
-        for (int i = 0; i < app.spellList[app.spellBook].length; i++) {
-            app.spellList[row][i] = Spell.spells.get(i + 20);
-        }
-        jTable1.getModel().setValueAt(app.spellList[row][0].getName(), row, 0);
-        jTable1.getModel().setValueAt(app.spellList[row][1].getName(), row, 1);
-        jTable1.getModel().setValueAt(app.spellList[row][2].getName(), row, 2);
-        jTable1.getModel().setValueAt(app.spellList[row][3].getName(), row, 3);
-        jTable1.getModel().setValueAt(app.spellList[row][4].getName(), row, 4);
-    }// GEN-LAST:event_jButton6ActionPerformed
+    } // Consolidated from the button listeners
 
     public void loadSpells() {
         int spells[][];

--- a/src/main/java/com/johnwesthoff/bending/ui/Verify.java
+++ b/src/main/java/com/johnwesthoff/bending/ui/Verify.java
@@ -47,10 +47,17 @@ public class Verify extends javax.swing.JFrame {
 
         jLabel1.setText("Code:");
 
-        username.addActionListener(event -> usernameActionPerformed(event));
+        username.addActionListener(event -> {
+                // Do nothing (potentially run username validation)
+        });
 
         jButton1.setText("Verify");
-        jButton1.addActionListener(event -> jButton1ActionPerformed(event));
+        jButton1.addActionListener(event -> {
+                if (playerService.verify(username.getText())) {
+                        JOptionPane.showMessageDialog(rootPane, "Verification Complete!");
+                }
+                setVisible(false);
+        });
 
         javax.swing.GroupLayout layout = new javax.swing.GroupLayout(getContentPane());
         getContentPane().setLayout(layout);
@@ -73,18 +80,6 @@ public class Verify extends javax.swing.JFrame {
 
         pack();
     }// </editor-fold>//GEN-END:initComponents
-
-    private void usernameActionPerformed(java.awt.event.ActionEvent evt) {// GEN-FIRST:event_usernameActionPerformed
-
-    }// GEN-LAST:event_usernameActionPerformed
-
-    private void jButton1ActionPerformed(java.awt.event.ActionEvent evt) {// GEN-FIRST:event_jButton1ActionPerformed
-
-        if (playerService.verify(username.getText())) {
-            JOptionPane.showMessageDialog(rootPane, "Verification Complete!");
-        }
-        setVisible(false);
-    }// GEN-LAST:event_jButton1ActionPerformed
 
     /**
      * @param args the command line arguments

--- a/src/main/java/com/johnwesthoff/bending/ui/Verify.java
+++ b/src/main/java/com/johnwesthoff/bending/ui/Verify.java
@@ -47,18 +47,10 @@ public class Verify extends javax.swing.JFrame {
 
         jLabel1.setText("Code:");
 
-        username.addActionListener(new java.awt.event.ActionListener() {
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
-                usernameActionPerformed(evt);
-            }
-        });
+        username.addActionListener(event -> usernameActionPerformed(event));
 
         jButton1.setText("Verify");
-        jButton1.addActionListener(new java.awt.event.ActionListener() {
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
-                jButton1ActionPerformed(evt);
-            }
-        });
+        jButton1.addActionListener(event -> jButton1ActionPerformed(event));
 
         javax.swing.GroupLayout layout = new javax.swing.GroupLayout(getContentPane());
         getContentPane().setLayout(layout);


### PR DESCRIPTION
Initially tackled the issues flagged by sonarlint rule java:S1604 (https://rules.sonarsource.com/java/RSPEC-1604), "Anonymous inner classes containing only one method should become lambdas", then followed up by also tackling sonarlint rule java:S1612 (https://rules.sonarsource.com/java/RSPEC-1612), "Lambdas should be replaced with method references".

The most common reason for the 1604 rule was that JButtons were being declared and given an ActionListener that was a new java.awt.event.ActionListener, and the intention of the rule seemed to be making it so that the buttons would get a lambda which had less overhead.  That conversion was fairly easy, if you follow the commits I initially replaced them (at least the majority) with simply removing the "new ActionListener()" bit and just opening a lambda function with "event ->".  For consistency and to build momentum, I completed that for all occurrences of the 1604 rule that I could find across the full source tree; was definitely most common with JButtons in the ui code.

Then, the linter was following up on the majority of these new lambda functions with the 1612 rule, and I have arrived at the conclusion that this warning was intended to not have a pass-through lambda function that accepts an event and then calls another method with the exact same signature and just passes the event along.  To my understanding, that would both be a frivolous step, and it makes the code less readable for maintenance.  So, instead of passing things along, and also to not have to re-write the signature for all those button listener methods to have public visibility, I looked for a smoother alternative.

After looking over the majority of the button listener methods, they were quite simple (several even one-liners), so instead of
passing them as a method reference I just moved the method body up into the lambda function itself and erased the method from the later part of the file.  I promise I was diligent in individually looking up each and copying each individual method body out to the correct lambda declaration before deleting the method body, but by all means feel free to review (several are quite intuitive).  The changes, I must admit, made the code vastly more readable.

There were a couple of methods that were too long to aesthetically fit in a lambda, so I discovered that changing the method signature by dropping the event (which was unused) cleared up the lint warning as well.  For those, I did exactly that, except for the buttons in SpellList1.java - they were so nearly identical that I just crafted one method to handle them all, jButtonLoadSpells(int startIndex).

Hopefully these changes all are intuitive, and are useful.  After these modifications I do believe all my sections of code are clear of errors and didn't replace one sonarlint warning with another (there are other types of sonarlint warnings still present, but I wanted to go ahead and get these contributions on board).

I did not do exhaustive testing to ensure that all functionality was carried over, but since these changes were almost purely relocating method bodies withing the code and did not cause any substantive changes, I finished out testing by launching the client, initiating a new server, loading the loadouts and gear windows, and interacting with several of the controls (including the ones that were part of the edits), and the behavior seemed to be appropriate.

Thanks for the opportunity!  I might tackle some more lint issues, time permitting, and in case I don't, happy Hacktoberfest!